### PR TITLE
fix: updates for iOS 11.4 & Xcode 9.4

### DIFF
--- a/DeformableMesh.xcodeproj/project.pbxproj
+++ b/DeformableMesh.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		23C3FC4420C3DE090033581F /* SCNGeometrySource+Additions.m in Sources */ = {isa = PBXBuildFile; fileRef = 23C3FC4320C3DE090033581F /* SCNGeometrySource+Additions.m */; };
 		736CC9CF201FECF600058CC4 /* texture.png in Resources */ = {isa = PBXBuildFile; fileRef = 736CC9CE201FECF600058CC4 /* texture.png */; };
 		73707E4F1C01D0F800A569AA /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73707E4E1C01D0F800A569AA /* AppDelegate.swift */; };
 		73707E511C01D0F800A569AA /* art.scnassets in Resources */ = {isa = PBXBuildFile; fileRef = 73707E501C01D0F800A569AA /* art.scnassets */; };
@@ -20,6 +21,9 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		23C3FC4120C3DE090033581F /* DeformableMesh-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "DeformableMesh-Bridging-Header.h"; sourceTree = "<group>"; };
+		23C3FC4220C3DE090033581F /* SCNGeometrySource+Additions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "SCNGeometrySource+Additions.h"; sourceTree = "<group>"; };
+		23C3FC4320C3DE090033581F /* SCNGeometrySource+Additions.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "SCNGeometrySource+Additions.m"; sourceTree = "<group>"; };
 		736CC9CE201FECF600058CC4 /* texture.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = texture.png; sourceTree = "<group>"; };
 		73707E4B1C01D0F800A569AA /* DeformableMesh.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = DeformableMesh.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		73707E4E1C01D0F800A569AA /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -75,6 +79,9 @@
 				73707E5C1C01D0F800A569AA /* Info.plist */,
 				73707E621C01D2BF00A569AA /* MetalMeshDeformable.swift */,
 				73707E661C02D8E300A569AA /* DeformCompute.metal */,
+				23C3FC4220C3DE090033581F /* SCNGeometrySource+Additions.h */,
+				23C3FC4320C3DE090033581F /* SCNGeometrySource+Additions.m */,
+				23C3FC4120C3DE090033581F /* DeformableMesh-Bridging-Header.h */,
 			);
 			path = DeformableMesh;
 			sourceTree = "<group>";
@@ -106,13 +113,13 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0710;
-				LastUpgradeCheck = 0820;
+				LastUpgradeCheck = 0930;
 				ORGANIZATIONNAME = "Lachlan Hurst";
 				TargetAttributes = {
 					73707E4A1C01D0F800A569AA = {
 						CreatedOnToolsVersion = 7.1.1;
-						DevelopmentTeam = 4F7DKRYKP6;
-						LastSwiftMigration = 0820;
+						DevelopmentTeam = JVS5Q57ZPX;
+						LastSwiftMigration = 0940;
 					};
 				};
 			};
@@ -159,6 +166,7 @@
 				73707E531C01D0F800A569AA /* GameViewController.swift in Sources */,
 				73707E4F1C01D0F800A569AA /* AppDelegate.swift in Sources */,
 				73707E651C02D3F900A569AA /* SCNVector3Extensions.swift in Sources */,
+				23C3FC4420C3DE090033581F /* SCNGeometrySource+Additions.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -192,14 +200,22 @@
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
@@ -239,14 +255,22 @@
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
@@ -276,12 +300,16 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				DEVELOPMENT_TEAM = 4F7DKRYKP6;
+				CLANG_ENABLE_MODULES = YES;
+				DEVELOPMENT_TEAM = JVS5Q57ZPX;
 				INFOPLIST_FILE = DeformableMesh/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = com.lachlanhurst.DeformableMesh;
+				PRODUCT_BUNDLE_IDENTIFIER = co.net5.DeformableMesh;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
+				SWIFT_OBJC_BRIDGING_HEADER = "DeformableMesh/DeformableMesh-Bridging-Header.h";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_SWIFT3_OBJC_INFERENCE = On;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Debug;
 		};
@@ -289,12 +317,15 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				DEVELOPMENT_TEAM = 4F7DKRYKP6;
+				CLANG_ENABLE_MODULES = YES;
+				DEVELOPMENT_TEAM = JVS5Q57ZPX;
 				INFOPLIST_FILE = DeformableMesh/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = com.lachlanhurst.DeformableMesh;
+				PRODUCT_BUNDLE_IDENTIFIER = co.net5.DeformableMesh;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
+				SWIFT_OBJC_BRIDGING_HEADER = "DeformableMesh/DeformableMesh-Bridging-Header.h";
+				SWIFT_SWIFT3_OBJC_INFERENCE = On;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Release;
 		};

--- a/DeformableMesh/DeformableMesh-Bridging-Header.h
+++ b/DeformableMesh/DeformableMesh-Bridging-Header.h
@@ -1,0 +1,5 @@
+//
+//  Use this file to import your target's public headers that you would like to expose to Swift.
+//
+
+#import "SCNGeometrySource+Additions.h"

--- a/DeformableMesh/GameViewController.swift
+++ b/DeformableMesh/GameViewController.swift
@@ -147,13 +147,15 @@ class GameViewController: UIViewController, SCNSceneRendererDelegate {
             
             let result = hitResults.first!
             
-            let loc = SCNVector3ToFloat3(result.localCoordinates)
-            
+//            let loc = SCNVector3ToFloat3(result.localCoordinates)
+			let loc = float3.init(result.localCoordinates)
+			
             let globalDir = self.cameraZaxis(scnView) * -1
             let localDir  = result.node.convertPosition(globalDir, from: nil)
             
-            let dir = SCNVector3ToFloat3(localDir)
-            
+//            let dir = SCNVector3ToFloat3(localDir)
+			let dir = float3.init(localDir)
+			
             let dd = DeformData(location:loc, direction:dir, radiusSquared:16.0, deformationAmplitude: 1.5, pad1: 0, pad2: 0)
             self.deformData = dd
 
@@ -164,7 +166,7 @@ class GameViewController: UIViewController, SCNSceneRendererDelegate {
         }
     }
 
-    func newMesh() {
+    @objc func newMesh() {
         let scnView = self.view as! SCNView
         
         meshData = MetalMeshDeformable.buildPlane(device, width: width, length: length, step: step)

--- a/DeformableMesh/SCNGeometrySource+Additions.h
+++ b/DeformableMesh/SCNGeometrySource+Additions.h
@@ -1,0 +1,35 @@
+//
+//  SCNGeometrySource+Additions.h
+//  DeformableMesh
+//
+//  Created by Simon Wilson on 3/6/18.
+//  Copyright © 2018 Simon Wilson. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import <SceneKit/SceneKit.h>
+#import <Metal/Metal.h>
+
+// In iOS 11.4, this function is defined behind the SCN_ENABLE_METAL macro. It defaults to 1, but Swift can't see it, so we don't end up
+// with an appropriate Swift version. This extension allows us to properly use this method.
+//
+// I am not a Swift developer, so I'm not sure if there's a better way to do this, but it works... 
+@interface SCNGeometrySource ()
++ (instancetype)geometrySourceWithBuffer:(id <MTLBuffer>)mtlBuffer vertexFormat:(MTLVertexFormat)vertexFormat semantic:(SCNGeometrySourceSemantic)semantic vertexCount:(NSInteger)vertexCount dataOffset:(NSInteger)offset dataStride:(NSInteger)stride API_AVAILABLE(macos(10.11), ios(9.0));
+@end

--- a/DeformableMesh/SCNGeometrySource+Additions.m
+++ b/DeformableMesh/SCNGeometrySource+Additions.m
@@ -1,0 +1,28 @@
+//
+//  SCNGeometrySource+Additions.m
+//  DeformableMesh
+//
+//  Created by Simon Wilson on 3/6/18.
+//  Copyright © 2018 Simon Wilson. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import "SCNGeometrySource+Additions.h"
+
+// No code required here


### PR DESCRIPTION
The one method of SCNGeometrySource that we need most is hidden behind a
silly macro, so I define an extension which allows Swift to find it.

This commit also fixes up some of the swift compile errors. I'm not a
Swift hacker, so I've just followed what the compiler suggested that I
do. ? and ! after variables?!?!?!?!??!

Runs successfully on my iPhone 7 plus running iOS 11.4.